### PR TITLE
Fix support for SCSS files

### DIFF
--- a/lib/calatrava/manifest.rb
+++ b/lib/calatrava/manifest.rb
@@ -34,15 +34,16 @@ module Calatrava
     def haml_files
       @shell.haml_files + feature_files(@shell, :haml)
     end
-    
+
     def css_files
       @shell.css_files
     end
 
     def css_tasks(output_dir)
+      directory output_dir
       css_files.collect do |style_file|
         file "#{output_dir}/#{File.basename(style_file, '.*')}.css" => [output_dir, style_file] do |t|
-          if style_file =~ /css$/
+          if style_file =~ /\.css$/
             cp style_file, output_dir
           else
             sh "sass #{style_file} #{t.name}"

--- a/lib/calatrava/shell.rb
+++ b/lib/calatrava/shell.rb
@@ -19,7 +19,7 @@ module Calatrava
 
     def css_files
       Dir.chdir @path do
-        Dir["shell/stylesheets/*.sass"] + Dir["shell/stylesheets/*.css"]
+        Dir["shell/stylesheets/*.sass"] + Dir["shell/stylesheets/*.scss"] + Dir["shell/stylesheets/*.css"]
       end
     end
 


### PR DESCRIPTION
- Include *.scss files in the list of stylesheet files.
- Run scss files through the `sass` interpreter instead of copying them to
  the output directory like plain css files.
- Make sure the styles output directory is created first. Copying a
  plain css file creates that folder automatically. But `sass` does not
  create the output directory, hence if no plain css files exist then
  `sass` would fail.
