### PR TITLE
Fail build on errors when compiling coffee script

### DIFF
--- a/lib/calatrava/tasks/assets.rb
+++ b/lib/calatrava/tasks/assets.rb
@@ -5,6 +5,7 @@ end
 def coffee(in_dir_or_file, out_dir)
   if !Dir["#{in_dir_or_file}/**/*.coffee"].empty? || File.exists?(in_dir_or_file)
     $stdout.puts "coffee #{in_dir_or_file} -> #{out_dir}"
-    system "node_modules/coffee-script/bin/coffee --compile --output #{out_dir} #{in_dir_or_file}"
+    ok = system "node_modules/coffee-script/bin/coffee --compile --output #{out_dir} #{in_dir_or_file}"
+    fail "Error compiling coffee script. Did you run `npm install`?" if !ok
   end
 end


### PR DESCRIPTION
It would help if the rake tasks fails when coffee script cannot be compiled (say due to missing coffee executable).

Had me wondering yesterday for quite some time when setting up a Jenkins build step.
