### PR TITLE
Fix for Android not compiling out of the box

### DIFF
--- a/lib/calatrava/templates/droid/calatrava/src/com/CALATRAVA_TMPL/Bootstrap.java.calatrava
+++ b/lib/calatrava/templates/droid/calatrava/src/com/CALATRAVA_TMPL/Bootstrap.java.calatrava
@@ -13,9 +13,10 @@ public class Bootstrap extends Activity
     super.onCreate(savedInstanceState);
     setContentView(R.layout.main);
 
-    ((CalatravaApplication)getApplication()).provideActivityContext(this);
+    CalatravaApplication app = (CalatravaApplication)getApplication();
+    app.provideActivityContext(this);
 
     // And then start your first feature
-    launchFlow("example.converter.start");
+    app.launchFlow("example.converter.start");
   }
 }


### PR DESCRIPTION
In `Bootstrap.java`, `launchFlow` isn't a static method anymore, so it needs to be called on
an instance of the application.

This prevents the Android part of Calatrava from compiling.
