### PR TITLE
[droid] Use a default WebViewActivity if no custom Activity exists

### DIFF
--- a/lib/calatrava/templates/droid/calatrava/CALATRAVA_TMPL/AndroidManifest.xml.calatrava
+++ b/lib/calatrava/templates/droid/calatrava/CALATRAVA_TMPL/AndroidManifest.xml.calatrava
@@ -12,8 +12,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".ConversionForm"
-                  android:label="@string/app_name">
-        </activity>
+        <activity android:name="com.calatrava.shell.WebViewActivity" android:label="@string/app_name" />
+        <activity android:name=".ConversionForm" android:label="@string/app_name"/ >
     </application>
 </manifest> 

--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/PageRegistry.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/PageRegistry.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import org.mozilla.javascript.ScriptableObject;
 
 import com.calatrava.CalatravaPage;
+import com.calatrava.shell.WebViewActivity;
 
 import java.util.*;
 
@@ -76,8 +77,13 @@ public class PageRegistry {
   public void changePage(String target) {
     Log.d(TAG, "changePage('" + target + "')");
     Class activityClass = pageFactories.get(target);
+
+    if (activityClass == null) {
+      activityClass = WebViewActivity.class;
+    }
+
     Log.d(TAG, "Activity to be started: " + activityClass.getSimpleName());
-    activityContext.startActivity(new Intent(activityContext, activityClass));
+    activityContext.startActivity(new Intent(activityContext, activityClass).putExtra("pageName", target));
   }
 
   public void triggerEvent(String pageName, String event, String... extraArgs) {

--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/shell/WebViewActivity.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/shell/WebViewActivity.java
@@ -17,6 +17,7 @@ import com.calatrava.bridge.RegisteredActivity;
 import com.calatrava.bridge.RhinoService;
 import com.calatrava.bridge.PageRegistry;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
 
-public abstract class WebViewActivity extends RegisteredActivity {
+public class WebViewActivity extends RegisteredActivity {
   private String TAG = WebViewActivity.class.getSimpleName();
 
   private JSContainer jsContainer;
@@ -74,6 +75,11 @@ public abstract class WebViewActivity extends RegisteredActivity {
     PageRegistry.sharedRegistry().unregisterPage(getPageName());
   }
 
+  @Override
+  protected String getPageName() {
+    return getIntent().getStringExtra("pageName");
+  }
+
   public String getFieldValue(final String field) {
     assert (getFields().contains(field));
 
@@ -112,9 +118,13 @@ public abstract class WebViewActivity extends RegisteredActivity {
     });
   }
 
-  protected abstract List<String> getEvents();
+  protected List<String> getEvents() {
+    return new ArrayList<String>();
+  }
 
-  protected abstract List<String> getFields();
+  protected List<String> getFields() {
+    return new ArrayList<String>();
+  }
     
   protected int getBackgroundColor(){
     return Color.TRANSPARENT;


### PR DESCRIPTION
Similar to [Pull Request 7](https://github.com/calatrava/calatrava-ios/pull/7) for iOS this changes makes it so you don't need to create an empty Activity to use the shell views.

The change makes the WebViewActivity concrete, and it'll try to read a pageName from the intent that created it; the PageRegistry will now pass the pageName to the intent whenever it creates an Activity, and will default to using WebViewActivity.class whenever it can't find a
matching Activity.
