### PR TITLE
Always recompile assets on build, fix for dependency issue

### DIFF
--- a/lib/calatrava/app_builder.rb
+++ b/lib/calatrava/app_builder.rb
@@ -40,7 +40,7 @@ module Calatrava
       directory build_styles_dir
 
       app_files = haml_files.collect do |hf|
-        file "#{build_html_dir}/#{File.basename(hf, '.haml')}.html" => [build_html_dir, hf] do
+        task do
           HamlSupport::compile_hybrid_page hf, build_html_dir, :platform => @platform
         end
       end

--- a/lib/calatrava/output_file.rb
+++ b/lib/calatrava/output_file.rb
@@ -40,7 +40,7 @@ module Calatrava
     alias :to_s :output_path
 
     def to_task
-      file(output_path => @dependencies) do
+      task do
         OutputFile.action(@source_file).call(output_path.to_s, @source_file.to_s)
       end
     end


### PR DESCRIPTION
Assets weren't being recompiled when a file they depend on change, this was most evident with changing the `single_page.haml` and all the other pages wouldn't recompile.

This happens because the Rake File task will only execute if the target file either doesn't exist or its timestamp is older than the source file. This means the task won't execute if you change the layout without changing each file that uses it.

This change recompiles all the files every time a build is run. Obviously this is less than ideal, but without some kind of dependency graph it'll be difficult to conditionally compile things.
