### PR TITLE
Fix for back button being broken in web apps

### DIFF
--- a/lib/calatrava/templates/web/app/source/init.coffee
+++ b/lib/calatrava/templates/web/app/source/init.coffee
@@ -8,4 +8,4 @@ $(document).ready ->
 
 window.onpopstate = (event) ->
   if event.state
-    tw.bridge.changePage event.state.page
+    calatrava.bridge.changePage event.state.page


### PR DESCRIPTION
Tiny fix. `init.coffee` was still referring to the `tw.bridge` rather than `calatrava.bridge`, so `changePage` is undefined.
