### PR TITLE
Try to catch unhandled exceptions in Android JS execution

### DIFF
--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/RhinoService.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/RhinoService.java
@@ -197,7 +197,12 @@ public class RhinoService {
     }
 
     private void eval(String jsCode) {
-      ctxt.evaluateString(mScope, jsCode, "<Bridge>", 1, null);
+      String safe = "(function() { try { return " + jsCode + "; } catch (ex) { return '@@EX@@' + ex.toString() + '\\n' + ex.stack.toString(); } })()";
+      Object result = ctxt.evaluateString(mScope, safe, "<Bridge>", 1, null);
+
+      if (result != null && result.toString().startsWith("@@EX@@")) {
+        throw new RuntimeException("JavaScript Unhandled Exception\n"+result.toString().substring(6));
+      }
     }
 
   }

--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/shell/WebViewActivity.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/shell/WebViewActivity.java
@@ -36,7 +36,7 @@ public abstract class WebViewActivity extends RegisteredActivity {
     public void onReceive(Context context, Intent intent) {
       if ("com.calatrava.dialog".equals(intent.getAction())) {
         String name = intent.getExtras().getString("name");
-        webView.loadUrl("javascript:window." + getPageName() + "View.showDialog('" + name + "');");
+        safeExecuteJavaScript("window." + getPageName() + "View.showDialog('" + name + "');");
       }
     }
   };
@@ -81,7 +81,7 @@ public abstract class WebViewActivity extends RegisteredActivity {
 
     FutureTask<String> fieldValue = new FutureTask<String>(new Callable<String>() {
       public String call() throws Exception {
-        webView.loadUrl("javascript:container.provideValueFor('" + field + "', window." + getPageName() + "View.get('" + field + "'));");
+        safeExecuteJavaScript("container.provideValueFor('" + field + "', window." + getPageName() + "View.get('" + field + "'));");
         return jsContainer.retrieveValueFor(field);
       }
     });
@@ -107,7 +107,7 @@ public abstract class WebViewActivity extends RegisteredActivity {
         jsContainer.setJsObject(json);
         Log.d(TAG, "render page: " + getPageName());
 
-        webView.loadUrl("javascript:container.onRenderComplete(window." + getPageName() + "View.render(JSON.parse(container.getJsObject())));");
+        safeExecuteJavaScript("container.onRenderComplete(window." + getPageName() + "View.render(JSON.parse(container.getJsObject())));");
       }
     });
   }
@@ -171,6 +171,14 @@ public abstract class WebViewActivity extends RegisteredActivity {
     }
   }
 
+  private void safeExecuteJavaScript(String javascript) {
+    webView.loadUrl("javascript:" + makeSafe(javascript));
+  }
+
+  private static String makeSafe(String javascript) {
+    return "(function() { try { " + javascript + "; } catch (ex) { container.rethrowException(ex.stack.toString()); } })()";
+  }
+
   public class JSContainer {
     private String TAG = JSContainer.class.getSimpleName();
 
@@ -230,12 +238,21 @@ public abstract class WebViewActivity extends RegisteredActivity {
       triggerEvent(event, extraArgs);
     }
 
+    public void rethrowException(final String exception) {
+      runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          throw new RuntimeException("JavaScript Unhandled Exception\n" + exception);
+        }
+      });
+    }
+
     public void onRenderComplete(Object ignored) {
       runOnUiThread(new Runnable() {
         public void run() {
           for (String event : getEvents()) {
             Log.d(TAG, "About to bind event '" + event + "'");
-            webView.loadUrl("javascript:window." + getPageName() + "View.bind('" + event + "', function() { container.handleEvent('" + event + "', _.toArray(arguments)); });");
+            safeExecuteJavaScript("window." + getPageName() + "View.bind('" + event + "', function() { container.handleEvent('" + event + "', _.toArray(arguments)); });");
           }
         }
       });


### PR DESCRIPTION
Similar to the iOS changes, this wraps any call through to the JS runtime in a try...catch block and will rethrow any JS exceptions as native Android RuntimeExceptions.

This makes the Android app fail fast if there's an unhandled javascript exception.

It's implemented slightly differently to the iOS version. When it catches an exception it calls a new `rethrowException` method on the `JSContainer`, which throws a `RuntimeException` on the UI thread.
