### PR TITLE
Device specific stylesheets

### DIFF
--- a/lib/calatrava/app_builder.rb
+++ b/lib/calatrava/app_builder.rb
@@ -39,9 +39,10 @@ module Calatrava
       directory build_scripts_dir
       directory build_styles_dir
 
+      css_files = @manifest.css_files.map { |x| File.basename(x, '.*') + '.css' }
       app_files = haml_files.collect do |hf|
         file "#{build_html_dir}/#{File.basename(hf, '.haml')}.html" => [build_html_dir, hf] do
-          HamlSupport::compile_hybrid_page hf, build_html_dir, :platform => @platform
+          HamlSupport::compile_hybrid_page hf, build_html_dir, css_files, :platform => @platform
         end
       end
 

--- a/lib/calatrava/mobile_web_app.rb
+++ b/lib/calatrava/mobile_web_app.rb
@@ -41,12 +41,13 @@ module Calatrava
       directory images_build_dir
 
       app_files = coffee_files.collect { |cf| cf.to_task }
+      css_files = @manifest.css_files.map { |x| File.basename(x, '.*') + '.css' }
 
       app_files << file("#{build_dir}/index.html" => [@manifest.src_file,
                                                       "web/app/views/index.haml",
                                                       transient('web_coffee', coffee_files),
                                                       transient('web_haml', haml_files)] + haml_files) do
-        HamlSupport::compile "web/app/views/index.haml", build_dir
+        HamlSupport::compile "web/app/views/index.haml", build_dir, css_files
       end
 
       app_files += @manifest.css_tasks(styles_build_dir)

--- a/lib/calatrava/tasks/haml.rb
+++ b/lib/calatrava/tasks/haml.rb
@@ -4,9 +4,10 @@ module HamlSupport
 
   class Helper
     
-    attr_reader :page_name
+    attr_reader :page_name, :style_files
 
-    def initialize(page_path = nil)
+    def initialize(style_files, page_path = nil)
+      @style_files = style_files
       @page_path = page_path
       @page_name = File.basename(@page_path, '.haml') if @page_path
     end
@@ -37,20 +38,20 @@ module HamlSupport
 
   class << self
 
-    def compile_hybrid_page(page_path, output_path, options = {})
+    def compile_hybrid_page(page_path, output_path, style_files, options = {})
       puts "haml page: #{page_path} -> #{output_path}"
 
-      options[:helper] = Helper.new(page_path)
+      options[:helper] = Helper.new(style_files, page_path)
       options[:template] = "shell/layouts/single_page.haml"
       options[:out] = File.join(output_path, File.basename(page_path, '.*') + '.html')
 
       render_haml(options)
     end
 
-    def compile(haml_path, html_dir, options = {})
+    def compile(haml_path, html_dir, style_files, options = {})
       puts "haml: #{haml_path} -> #{html_dir}"
 
-      options[:helper] ||= Helper.new
+      options[:helper] ||= Helper.new style_files
       options[:template] = haml_path
       options[:out] = File.join(html_dir, File.basename(haml_path, '.*') + '.html')
 

--- a/lib/calatrava/templates/shell/layouts/single_page.haml
+++ b/lib/calatrava/templates/shell/layouts/single_page.haml
@@ -1,8 +1,8 @@
 !!!
 %html
   %head
-    -%w{reset app common device}.each do |filename|
-      %link(type="text/css" rel="stylesheet" media="all" href="../styles/#{filename}.css")
+    -style_files.each do |filename|
+      %link(type="text/css" rel="stylesheet" media="all" href="../styles/#{filename}")
 
     -%w{env zepto ICanHaz underscore calatrava bridge shell pageHelper}.each do |filename|
       %script(type="text/javascript" src="../scripts/#{filename}.js")


### PR DESCRIPTION
Any sass files prefixed with the device type (ios, droid, web) will only be included on that particular device; also, those files will be included after all other style sheets.

The manifest will list all the css files in the shell, the app builders will then filter that list removing any stylesheets prefixed with device ids that aren't the current device. Those files are exposed to the views through a `style_files` helper.

I'm not sure if this is the best implementation, it feels a bit rough. Open to suggestions.

The main use-case for this right now is for removing certain aspects of pages on devices; for example, hiding the header when iOS is using a navigation bar.
