### PR TITLE
Make gemspec more Linux-friendly

### DIFF
--- a/calatrava.gemspec
+++ b/calatrava.gemspec
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8; mode: ruby -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "calatrava/version"
-require "calatrava/platform"
 
 Gem::Specification.new do |s|
   s.name        = "calatrava"
@@ -31,8 +30,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "cucumber", "~> 1.2.1"
   s.add_runtime_dependency "watir-webdriver", "~> 0.6.1"
 
-  if Calatrava.platform == :mac
-    s.add_runtime_dependency "xcodeproj", ">= 0.4.0" 
-    s.add_runtime_dependency "cocoapods", "~> 0.16.0"
-  end
+  s.extensions = ["ext/mkrf_conf.rb"]
 end

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,29 @@
+# This is a hack to enable platform-specific dependencies in a single gem.
+# For background info see:
+# http://www.programmersparadox.com/2012/05/21/gemspec-loading-dependent-gems-based-on-the-users-system/
+
+# Code primarily borrowed from here:
+# https://github.com/mmzyk/gem_dependency_example
+
+require "rubygems/dependency_installer.rb"
+
+installer = Gem::DependencyInstaller.new
+begin
+
+  # I don't *think* you can use Calatrava.platform == :mac here as it seems
+  # RubyGems builds Ruby extensions without the dependencies declared in the gemspec.
+  if RUBY_PLATFORM =~ /darwin/
+    installer.install "xcodeproj", ">= 0.4.0"
+    installer.install "cocoapods", "~> 0.16.0"
+  end
+
+rescue Exception => ex
+  # Exit with a non-zero value to let RubyGems know something went wrong.
+  exit 1
+end
+
+# Since this is Ruby, RubyGems will attempt to run Rake.
+# If it doesn't find and successfully run a Rakefile, it errors out.
+File.open(File.join(File.dirname(__FILE__), "Rakefile"), "w") do |f|
+  f.write "task :default\n"
+end


### PR DESCRIPTION
Right now if you run `gem install calatrava` on Linux you'll encounter an error trying to build native extensions for Xcodeproj, as the gem hosted on RubyGems was built on a Mac. This change moves the platform-specific dependency installation into a "native extension" so that it can take place at gem-install time rather than package-build time.

For more info see this blog post:

http://www.programmersparadox.com/2012/05/21/gemspec-loading-dependent-gems-based-on-the-users-system/

Note that this approach is considered by some (including the author of the above post) to be a hack. However, the alternative is to create platform-specific gems, which feels even less desirable (at least to me).
