### PR TITLE
BindAll was not working since it could not find the bind method on pageO...

### DIFF
--- a/lib/calatrava/templates/kernel/app/calatrava.coffee
+++ b/lib/calatrava/templates/kernel/app/calatrava.coffee
@@ -89,7 +89,7 @@ calatrava.bridge.pageObject = (pageName) ->
     calatrava.bridge.runtime.attachProxyEventHandler(proxyId, event)
 
   bindAll: (options) ->
-    _.each options, (handler, event) => pageObject.bind event, handler
+    _.each options, (handler, event) => @bind event, handler
 
   dispatch: (event) ->
     args = _.toArray(arguments).slice(1)


### PR DESCRIPTION
BindAll was not working since it could not find the bind method on pageObject. Changed it to call bind on 'this'
