### PR TITLE
Passed forward the error response in a ajax call failure

### DIFF
--- a/lib/calatrava/templates/web/app/source/bridge.coffee
+++ b/lib/calatrava/templates/web/app/source/bridge.coffee
@@ -64,9 +64,9 @@ calatrava.bridge.web.ajax = (options) ->
     success: (response) ->
       goToTop()
       options.success(response)
-    error: () ->
+    error: (response) ->
       showLoader()
-      options.failure() if options.failure?
+      options.failure(response) if options.failure?
     complete: hideLoader
 
 calatrava.bridge.web.page = (pageName, proxyId) ->


### PR DESCRIPTION
The error response from server was not passed forward to repositories. Having access to failure response will allow code to extract error messages and http status codes returned from server.
