### PR TITLE
Passed forward the error response in a ajax call failure.

### DIFF
--- a/lib/calatrava/templates/web/app/source/bridge.coffee
+++ b/lib/calatrava/templates/web/app/source/bridge.coffee
@@ -64,9 +64,9 @@ calatrava.bridge.web.ajax = (options) ->
     success: (response) ->
       goToTop()
       options.success(response)
-    error: () ->
+    error: (response) ->
       showLoader()
-      options.failure() if options.failure?
+      options.failure(response) if options.failure?
     complete: hideLoader
 
 calatrava.bridge.web.page = (pageName, proxyId) ->


### PR DESCRIPTION
_Submitting the pull request again, as I closed the last pull request by mistake._

In web ajax error response, current bridge.coffee eats the error response sent from server. It would be nice to get a handle to it, since it may contain relevant information that needs to be displayed.
