### PR TITLE
Service endpoint override for web in bridge.coffee doesn't work

### DIFF
--- a/lib/calatrava/templates/web/app/source/bridge.coffee
+++ b/lib/calatrava/templates/web/app/source/bridge.coffee
@@ -2,11 +2,6 @@ calatrava ?= {}
 calatrava.bridge = calatrava.bridge ? {}
 calatrava.bridge.web = calatrava.bridge.web ? {}
 
-calatrava.bridge.environment = () ->
-  sessionTimeout: 600
-  serviceEndpoint: ""
-  apiEndpoint: ""
-
 calatrava.bridge.web.ajax = (options) ->
   loader = $("#loader")
 

--- a/lib/calatrava/templates/web/app/source/override.config.web.coffee
+++ b/lib/calatrava/templates/web/app/source/override.config.web.coffee
@@ -1,0 +1,8 @@
+calatrava ?= {}
+calatrava.bridge = calatrava.bridge ? {}
+
+calatrava.bridge.environment = () ->
+  sessionTimeout: 600
+  serviceEndpoint: ""
+  apiEndpoint: ""
+


### PR DESCRIPTION
Moving the config override from bridge.coffe to override.config.web.coffee. This is to ensure that override happens as intended. Currently env.js provides the environment configuration which is always loaded after bridge.js and hence the intended override never happens. Until we build a loading priority of sorts, moving the override in an appropriatly named file will be a quick fix.

Ideally I would like it to teams to decide how they want to override endpoints for web; however if calatrava generates a template that doesn't work, then it leads to time spent debugging which should be avoided. 
