### PR TITLE
Can't add additional JS libraries to Javascript runtime running kernel code

### DIFF
--- a/lib/calatrava/app_builder.rb
+++ b/lib/calatrava/app_builder.rb
@@ -22,11 +22,27 @@ module Calatrava
       "#{build_scripts_dir}/#{File.basename(cf, '.coffee')}.js"
     end
 
-    def load_instructions
+    def change_path_to_relative files, &change_file_path
       build_path = Pathname.new(File.dirname(build_dir))
-      @manifest.kernel_bootstrap.collect do |cf|
-        Pathname.new(js_file(cf)).relative_path_from(build_path).to_s
-      end.join($/)
+      files.collect do |file_to_add|
+        Pathname.new(change_file_path.call(file_to_add)).relative_path_from(build_path).to_s
+      end
+    end
+
+    def library_files
+      change_path_to_relative @manifest.kernel_libraries do |js_library|
+        "#{build_scripts_dir}/#{File.basename(js_library)}"
+      end
+    end
+
+    def feature_files
+      change_path_to_relative @manifest.kernel_bootstrap do |coffee_file|
+        js_file(coffee_file)
+      end
+    end
+
+    def load_instructions
+      feature_files.concat(library_files).join($/)
     end
 
     def haml_files

--- a/lib/calatrava/manifest.rb
+++ b/lib/calatrava/manifest.rb
@@ -8,7 +8,13 @@ module Calatrava
     def initialize(path, app_dir, kernel, shell)
       @path, @kernel, @shell = path, kernel, shell
       @src_file = "#{app_dir}/manifest.yml"
-      @feature_list = YAML.load(IO.read("#{@path}/#{@src_file}"))
+      files_to_load = YAML.load(IO.read("#{@path}/#{@src_file}"))
+      @feature_list = files_to_load["features"]
+      @kernel_libraries = files_to_load["kernel_libs"] || []
+    end
+
+    def kernel_libraries
+      @kernel_libraries
     end
 
     def features

--- a/lib/calatrava/templates/droid/manifest.yml
+++ b/lib/calatrava/templates/droid/manifest.yml
@@ -1,1 +1,4 @@
-- converter
+features:
+  - converter
+kernel_libs:
+#  - assets/lib/underscore.js

--- a/lib/calatrava/templates/ios/manifest.yml
+++ b/lib/calatrava/templates/ios/manifest.yml
@@ -1,1 +1,4 @@
-- converter
+features:
+  - converter
+kernel_libs:
+#  - assets/lib/underscore.js

--- a/lib/calatrava/templates/web/manifest.yml
+++ b/lib/calatrava/templates/web/manifest.yml
@@ -1,1 +1,4 @@
-- converter
+features:
+  - converter
+kernel_libs:
+#  - assets/lib/underscore.js

--- a/spec/app_builder_spec.rb
+++ b/spec/app_builder_spec.rb
@@ -13,7 +13,8 @@ describe Calatrava::AppBuilder do
   let(:manifest) { double('web mf',
                           :coffee_files => ['path/to/kernel.coffee', 'diff/path/shell.coffee'],
                           :kernel_bootstrap => ['path/to/kernel.coffee'],
-                          :haml_files => ['diff/path/shell.haml']) }
+                          :haml_files => ['diff/path/shell.haml'],
+                          :kernel_libraries => ['path/to/external/kernel_lib.js']) }
   
   let(:app) { Calatrava::AppBuilder.new('app', 'app/build', manifest) }
 
@@ -32,9 +33,10 @@ describe Calatrava::AppBuilder do
   end
 
   context '#load_file' do
-    subject { app.load_instructions.lines.to_a }
+    subject { app.load_instructions.lines.to_a.each(&:chomp!) }
     
     it { should include 'build/scripts/kernel.js' }
+    it { should include 'build/scripts/kernel_lib.js' }
     it { should_not include 'build/scripts/shell.js' }
   end
 
@@ -43,4 +45,5 @@ describe Calatrava::AppBuilder do
 
     it { should include 'diff/path/shell.haml' }
   end
+
 end

--- a/spec/manifest_spec.rb
+++ b/spec/manifest_spec.rb
@@ -6,7 +6,7 @@ describe Calatrava::Manifest do
 
   before(:each) do
     create_dir 'app'
-    write_file 'app/manifest.yml', ['included'].to_yaml
+    write_file 'app/manifest.yml', {'features' => ['included'], 'kernel_libs' => ['kernel_lib.js']}.to_yaml
   end
 
   let(:features) {  }
@@ -57,6 +57,24 @@ describe Calatrava::Manifest do
     it { should_not include 'k_exc' }
     it { should_not include 'shell_everywhere' }
     it { should_not include 'shell_inc' }
+  end
+
+  context '#kernel_libraries' do
+    context "#when present" do
+      subject { manifest.kernel_libraries }
+
+      it { should include 'kernel_lib.js'}
+    end
+
+    context "#when not present" do
+      before do
+        write_file 'app/manifest.yml', {'features' => ['included'], 'kernel_libs' => nil}.to_yaml
+      end
+
+      subject { manifest.kernel_libraries }
+
+      it { should be_empty}
+    end
   end
 
 end


### PR DESCRIPTION
**This commit changes the structure of manifest.yaml and may not be backward compatible for existing apps**
_It requires some discussion as to how migrations for existing apps need to be supported since I have not seen an automated way to upgrade calatrava in existing apps_
Some details [here](https://groups.google.com/forum/#!topic/calatrava-mobile/8RlO6W8qF1c) as well.

**Commit Details**
Adding the ability to specify js libraries that need to be loaded with js runtime running kernel code. This change alters the structure of mainfest.yml for all three projects by adding features and kernel_libs as two distinct sections. Any files added in kernel_libs will be added to load_file.txt for all platforms and will be loaded while initializing the js runtime for kernel code.
