### PR TITLE
Made changes to enable render for Native Android views

### DIFF
--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/NativePageStateManager.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/NativePageStateManager.java
@@ -1,0 +1,32 @@
+package com.calatrava.bridge;
+
+import android.app.Activity;
+
+public class NativePageStateManager implements PageStateManager {
+
+  private RegisteredActivity activity;
+
+  public NativePageStateManager(Activity activity) {
+    this.activity = (RegisteredActivity) activity;
+  }
+
+  @Override
+  public void onCreateProcessing() {
+    activity.registerPage();
+  }
+
+  @Override
+  public void onResumeProcessing() {
+    activity.pageOnScreen();
+  }
+
+  @Override
+  public void onPauseProcessing() {
+    activity.pageOffScreen();
+  }
+
+  @Override
+  public void onDestroyProcessing() {
+    activity.unRegisterPage();
+  }
+}

--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/PageStateManager.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/PageStateManager.java
@@ -1,0 +1,13 @@
+package com.calatrava.bridge;
+
+public interface PageStateManager {
+
+  public void onCreateProcessing();
+
+  public void onResumeProcessing();
+
+  public void onPauseProcessing();
+
+  public void onDestroyProcessing();
+
+}

--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/shell/WebViewPageStateManager.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/shell/WebViewPageStateManager.java
@@ -1,0 +1,89 @@
+package com.calatrava.shell;
+
+import android.app.Activity;
+import android.util.Log;
+import android.webkit.JsResult;
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import com.calatrava.bridge.PageStateManager;
+
+public class WebViewPageStateManager implements PageStateManager {
+
+  private static final String TAG = WebViewPageStateManager.class.getSimpleName();
+  private WebViewActivity webViewActivity;
+  private WebViewActivity.JSContainer jsContainer;
+  private final String pageName;
+  private final WebView webView;
+
+  public WebViewPageStateManager(Activity activity, WebViewActivity.JSContainer jsContainer, String pageName, WebView webView) {
+    this.webViewActivity = (WebViewActivity) activity;
+    this.jsContainer = jsContainer;
+    this.pageName = pageName;
+    this.webView = webView;
+  }
+
+  public void onCreateProcessing() {
+    webViewActivity.registerPage();
+
+    webViewActivity.setContentView(webView);
+
+    webView.getSettings().setJavaScriptEnabled(true);
+    webView.getSettings().setDomStorageEnabled(true);
+    webView.setScrollBarStyle(webView.SCROLLBARS_OUTSIDE_OVERLAY);
+    webView.setScrollbarFadingEnabled(true);
+    webView.addJavascriptInterface(jsContainer, "container");
+
+    webView.setWebViewClient(new WebViewClient() {
+      @Override
+      public void onPageFinished(WebView view, String url) {
+        super.onPageFinished(view, url);
+        Log.d(TAG, "Webview finished loading a URL");
+
+        webViewActivity.pageReadiness(true);
+        onPageLoadCompleted();
+      }
+    });
+
+    webView.setWebChromeClient(new WebChromeClient() {
+      @Override
+      public boolean onJsAlert(WebView view, String url, String message, JsResult result) {
+        Log.d(TAG, "Received JS alert: '" + message + "'");
+        return false;
+      }
+    });
+
+    webView.loadUrl("file:///android_asset/calatrava/views/" + pageName + ".html");
+    pageHasOpened();
+  }
+
+  public void onResumeProcessing() {
+    onPageLoadCompleted();
+    pageHasOpened();
+  }
+
+  public void onPauseProcessing() {
+    webViewActivity.pageOffScreen();
+  }
+
+  public void onDestroyProcessing() {
+    webViewActivity.unRegisterPage();
+  }
+
+  private void onPageLoadCompleted() {
+    if (jsContainer != null && webViewActivity.pageState()) {
+      jsContainer.onRenderComplete(null);
+
+      for (String field : webViewActivity.getFields()) {
+        jsContainer.hasField(field);
+      }
+
+      webViewActivity.pageOnScreen();
+    }
+  }
+
+  private void pageHasOpened() {
+    webViewActivity.triggerEvent("pageOpened", new String[]{});
+  }
+
+}


### PR DESCRIPTION
Currently Android bridge worked with WebViewActivites only. This was primarily because the native pages were not registered or deregistered. Also events to indicate wether page was on screen or off screen were not published. 

Extraction of this logic as common is tricky in inheritance chain, since in WebViewActivity "OnScreen" call depends on WebView readiness callback, while it's called as part of onResume for Registered Activity. 

I have created corresponding state managers which are initialized in parent onCreate. They have android activity lifecycle hooks to do the processing, where one delegates the onScreen to callback and other calls it synchronously. 

I think this code can be structured better. But at this point I want to get it working. I'd be happy to refine it. Do comment with suggestions/approaches to design this better.
