### PR TITLE
Compile Kernel/Shell coffeescript files automatically upon change, when apache is running

### DIFF
--- a/lib/calatrava/apache.rb
+++ b/lib/calatrava/apache.rb
@@ -75,7 +75,7 @@ module Calatrava
       end
 
       desc "launch a non-daemon apache instance on port 8888 which will serve our local app and also proxy to backend services"
-      task :start => ['web:build', apache_public_dir, apache_logs_dir, "#{apache_conf_dir}/httpd.conf"] do
+      task :start => ['web:build', apache_public_dir, apache_logs_dir, "#{apache_conf_dir}/httpd.conf", 'web:autocompile'] do
         launch_apache
       end
 

--- a/lib/calatrava/mobile_web_app.rb
+++ b/lib/calatrava/mobile_web_app.rb
@@ -69,6 +69,13 @@ module Calatrava
         rm_rf build_dir
       end
 
+      desc "Auto compile shell and kernel files"
+      task :autocompile do
+        fork do
+          exec "ruby ./.auto_compile.rb"
+        end
+      end
+
       namespace :apache do
         @apache.install_tasks
       end

--- a/lib/calatrava/templates/.auto_compile.rb
+++ b/lib/calatrava/templates/.auto_compile.rb
@@ -1,0 +1,11 @@
+if Gem::Specification.find_all_by_name('filewatcher').count > 0
+  require 'filewatcher'
+  FileWatcher.new(Dir["kernel/app/**/*.coffee", "kernel/plugins/**/*coffee", "shell/**/*.coffee"]).watch do |filename|
+    puts "Recompiling file " + filename
+    system "node_modules/coffee-script/bin/coffee --compile --output web/public/scripts #{filename}"
+  end
+else
+  $stderr.puts("*"*100)
+  $stderr.puts("File watcher gem is not present as part of gem set. Your kernel and shell files won't be auto compiled.")
+  $stderr.puts("*"*100)
+end

--- a/lib/calatrava/templates/Gemfile.calatrava
+++ b/lib/calatrava/templates/Gemfile.calatrava
@@ -4,3 +4,6 @@ gem "rake"
 gem "calatrava"{{#dev?}}, :path => '../'{{/dev?}}
 {{#mac?}}gem "xcodeproj"
 gem "cocoapods"{{/mac?}}
+
+#auto compile shell and kernel for webapp. If you remove this, it'll stop auto compiling
+gem "filewatcher"


### PR DESCRIPTION
**It's NOT a issue but good to have feature.**

Added a small addition in setup to use filewatcher gem to specifically watch the coffee files in kernel/app/, kernel/plugins and shell/ for changes. Once a coffeescript file is changed it's automatically compiles to js and copied over to web/public/scripts. 

Since this is a add-on configuration; it's straight forward to override per project basis. To modify a user would need to modify .auto_compile.rb at project root and optionally remove filewatcher gem if not needed. 

web:apache:start rake tasks looks out for presence of "filewatcher" gem and will start the filewatcher as a child process, if present. If the gem is not present in gem set, it merely leaves a WARN to user indicating that since gem is missing auto compilation won't happen.
