### PR TITLE
Add /usr/local/bin to PATH in build_env.sh to fix #33

### DIFF
--- a/lib/calatrava/templates/build_env.sh
+++ b/lib/calatrava/templates/build_env.sh
@@ -1,2 +1,3 @@
+export PATH=$PATH:/usr/local/bin
 source ~/.rvm/scripts/rvm
 rvm rvmrc load


### PR DESCRIPTION
Add /usr/local/bin to PATH in build_env.sh to fix #33 without a manual workaroud. This allows the currency converter application's XCode build to pass on first attempt.
