### PR TITLE
Adding a default .gitignore file in the template 

### DIFF
--- a/lib/calatrava/templates/.gitignore
+++ b/lib/calatrava/templates/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 .idea/
 .node_updated
 ios/public/
+ios/*.xworkspace/
 .sass-cache/
 .rake/
 web/apache/conf/httpd.conf


### PR DESCRIPTION
Adding a default .gitignore file in the template so people don't check-in garbage into their own repos by mistake.
