### PR TITLE
Clean up automation tasks

### DIFF
--- a/lib/calatrava/tasks/automation.rb
+++ b/lib/calatrava/tasks/automation.rb
@@ -1,25 +1,14 @@
+ROOT_DIR ||= ".".freeze
 FEATURES_DIR = File.join('.', 'features').freeze
 FEATURE_RESULTS_DIR = File.join('.', 'results').freeze
 
 namespace :automation do
   namespace :web do
     desc "Runs cucumber tests against the web app"
-    task :features, [:file] => [:create_sim_link, :copy_steps_file, :clean_up_results_dir] do |t, args|
+    task :features, [:file] => [:clean_up_results_dir] do |t, args|
       ENV['PATH'] = "#{ROOT_DIR}/web/features:#{ENV['PATH']}"
       features_to_be_run = args[:file] ? "#{FEATURES_DIR}/#{args[:file]}" : FEATURES_DIR
       sh "cucumber --strict --tags @all,@web --tags ~@wip #{features_to_be_run} --format html --out #{FEATURE_RESULTS_DIR}/report.html --format pretty"
-    end
-
-    desc "create sim link for the ios step_definitions and support folder"
-    task :create_sim_link do
-      sh "rm -rf #{FEATURES_DIR}/step_definitions"
-      sh "rm -rf  #{FEATURES_DIR}/support"
-    end
-
-    desc "copy the web_steps file to web_steps.rb"
-    task :copy_steps_file do
-      sh "rm -f #{FEATURES_DIR}/*.rb"
-      sh "cp  #{FEATURES_DIR}/web_steps #{FEATURES_DIR}/web_steps.rb"
     end
 
     desc "delete and create the results dir"


### PR DESCRIPTION
ROOT_DIR not being set was causing rake automation:web:features[...] to fail.

Also, web_steps isn't provided by cucumber by default anymore (see: https://github.com/cucumber/cucumber-rails/blob/f027440965b96b780e84e50dd47203a2838e8d7d/History.md)

The create symlinks task looks like its just deleting things... doesn't make sense to me.
