### PR TITLE
Add a simple feature for testing the converter app

### DIFF
--- a/lib/calatrava/templates/Gemfile.calatrava
+++ b/lib/calatrava/templates/Gemfile.calatrava
@@ -7,3 +7,7 @@ gem "cocoapods", ">= 0.16.0"{{/mac?}}
 
 #auto compile shell and kernel for webapp. If you remove this, it'll stop auto compiling
 gem "filewatcher"
+
+group :test do
+  gem 'rspec'
+end

--- a/lib/calatrava/templates/features/converter.feature
+++ b/lib/calatrava/templates/features/converter.feature
@@ -1,0 +1,10 @@
+Feature: Converter
+  As an international traveller
+  I want to check if I am getting a good exchange rate
+  So that I can haggle and get a better rate
+
+  @web
+  Scenario: Converting to Aussie dollars
+    Given I have 100 USD
+    When I check conversion rate to AUD
+    Then the result should be greater than 100

--- a/lib/calatrava/templates/features/step_definitions/converter_steps.rb
+++ b/lib/calatrava/templates/features/step_definitions/converter_steps.rb
@@ -1,0 +1,29 @@
+Before do
+  @driver = Selenium::WebDriver.for :firefox
+end
+
+After do
+  @driver.quit
+end
+
+Given(/^I have (\d+) (.*)$/) do |amount, in_currency|
+  @driver.get "http://localhost:8888"
+  in_currency_selector = Selenium::WebDriver::Support::Select.new(@driver.find_element :id => "in_currency")
+  in_currency_selector.select_by :value, in_currency
+  in_amount = @driver.find_element :id => "in_amount"
+  in_amount.clear
+  in_amount.send_keys amount
+end
+
+When(/^I check conversion rate to (.*)$/) do |out_currency|
+  out_currency_selector = Selenium::WebDriver::Support::Select.new(@driver.find_element :id => "out_currency")
+  out_currency_selector.select_by :value, out_currency
+  convert_button = @driver.find_element :id => "convert"
+  convert_button.click
+end
+
+Then(/^the result should be greater than (\d+)$/) do |amount|
+  wait = Selenium::WebDriver::Wait.new(:timeout => 3) # seconds
+  wait.until { @driver.find_element(:id => "out_amount").attribute("value").to_f > 0 }
+  @driver.find_element(:id => "out_amount").attribute("value").to_f.should > amount.to_f
+end

--- a/lib/calatrava/templates/features/support/env.rb
+++ b/lib/calatrava/templates/features/support/env.rb
@@ -1,0 +1,2 @@
+require 'selenium-webdriver'
+require 'rspec-expectations'


### PR DESCRIPTION
Added a simple cuke so `rake automation:web:features[converter.feature]` will work by default in a template. This does require pull request #84 because otherwise, the step_definitions and support folders will get deleted by that rake task!
