### PR TITLE
Files and folders under asset folders are not copied recursively

### DIFF
--- a/lib/calatrava/tasks/assets.rb
+++ b/lib/calatrava/tasks/assets.rb
@@ -1,5 +1,5 @@
 def cp_ne(source, dest_dir)
-  cp Dir[source], dest_dir
+  cp_r Dir[source], dest_dir, :remove_destination => true
 end
 
 def coffee(in_dir_or_file, out_dir)


### PR DESCRIPTION
Currently folders under assets folder are limited to images and lib. While this is a great start, we need multiple folders directly under assets like Fonts and ability to support sub directories within those folders to be able to organize our code better. 

Here is a fix in a 2 step patch to copy all directories recursively from assets folder.

Instead of just copying file from source to destination; now we copy all files/directories recursively. This will help us move sub folders and files from asset folders to public folder. Calatrava build tasks error out right now if you place sub folders.

As part of the copy also first remove the existing copy of the file to ensure that we don't get overwrite prompt. 

I'd like to test this code either at unit level (where there is very little to test) or at functional level. I see that for cucumber features to support a build_and_deploy sort of feature, we would need gems to be installed; which in turn would be a time consuming activity. Is there a better option than actually installing gems as part of the run, that anyone can think off? My aim is to test the functioning of build and deploy tasks by asserting on resulting directory and app structure. 
