### PR TITLE
Fixing Calatrava build errors by changing jasmine-node version number

### DIFF
--- a/lib/calatrava/templates/package.json
+++ b/lib/calatrava/templates/package.json
@@ -8,7 +8,7 @@
     , "cucumber"      : "latest"
     , "jsdom"         : "latest"
     , "mime"          : "latest"
-    , "jasmine-node"  : "1.0.26"
+    , "jasmine-node"  : "1.5.0"
     , "should"        : "*"
     , "jasmine-reporters" : "*"
     , "walkdir"       : "*"


### PR DESCRIPTION
Incremented jasmine-node version to 1.5.0, which is a newer stable release as the older version was incompatible with latest version of node. This should make the calatrava build pass.
