### PR TITLE
Fix null pointer error for android plugins, when null data is passed

### DIFF
--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/PluginRegistry.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/PluginRegistry.java
@@ -104,7 +104,8 @@ public class PluginRegistry {
 
   public void invokeCallback(String callbackHandle, Object data)
   {
-    rhino.callJsFunction("calatrava.inbound.invokePluginCallback", new String[] {callbackHandle, data.toString()});
+    String callbackData = data == null ? null : data.toString();
+    rhino.callJsFunction("calatrava.inbound.invokePluginCallback", new String[] {callbackHandle, callbackData});
   }
 
   public void updateContext(Context activityContext)


### PR DESCRIPTION
Fix null pointer error when android plugins send null data eventually get converted to 'null' as string once it passes through bridge. For now apps willneed to handle this representation of null as well on either end.
