### PR TITLE
Avoid closing a null ProgressDialog object

### DIFF
--- a/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/RequestLoader.java
+++ b/lib/calatrava/templates/droid/calatrava/src/com/calatrava/bridge/RequestLoader.java
@@ -1,9 +1,7 @@
 package com.calatrava.bridge;
 
 import android.app.Activity;
-import android.app.ActivityManager;
 import android.app.ProgressDialog;
-import android.content.Context;
 import android.util.Log;
 
 public class RequestLoader {
@@ -26,6 +24,6 @@ public class RequestLoader {
   }
   
   public void onLoadingFinish() {
-    dialog.hide();
+    if(dialog != null) dialog.hide();
   }
 }


### PR DESCRIPTION
**This is not a complete fix**
This change merely avoids the app crashes. The side affect that still remains is, that sometimes between screen transition Progress loader may not appear at all. 

Fixing the null pointer error caused due to null dialog. This is not a complete fix. This only avoids the error; there is a change in approach required to fix this issue in long term

Also removed unused imports.
