### PR TITLE
upgraded cucumber gem to fix running features

### DIFF
--- a/calatrava.gemspec
+++ b/calatrava.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |s|
   s.add_development_dependency "aruba"
 
   s.add_runtime_dependency "rake", ">= 0.9.5"
-  
+
   s.add_runtime_dependency "thor", ">= 0.16.0"
   s.add_runtime_dependency "haml", "~> 3.1.7"
   s.add_runtime_dependency "sass", "~> 3.2.3"
   s.add_runtime_dependency "mustache", "~> 0.99.4"
-  s.add_runtime_dependency "cucumber", "~> 1.2.1"
+  s.add_runtime_dependency "cucumber", "~> 1.3.17"
   s.add_runtime_dependency "watir-webdriver", "~> 0.6.1"
 
   s.extensions = ["ext/mkrf_conf.rb"]


### PR DESCRIPTION
upgraded cucumber gem to fix mini test issue that was preventing features from running.

Stack trace observed after running 'rake test':

...........................................................

Finished in 0.04955 seconds (files took 0.24221 seconds to load)
59 examples, 0 failures
/Users/Thoughtworker/.rvm/rubies/ruby-2.1.5/bin/ruby -S bundle exec cucumber features --format pretty --tags ~@wip
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
From:
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/core_ext/disable_mini_and_test_unit_autorun.rb:3:in `require'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/core_ext/disable_mini_and_test_unit_autorun.rb:3:in`<top (required)>'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/runtime.rb:22:in `require'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/runtime.rb:22:in`initialize'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/cli/main.rb:40:in `new'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/cli/main.rb:40:in`execute!'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/cli/main.rb:20:in `execute'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/bin/cucumber:14:in`<top (required)>'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/cucumber:23:in `load'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/cucumber:23:in`<main>'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `eval'
  /Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in`<main>'
MiniTest::Unit::TestCase is now Minitest::Test. From /Users/Thoughtworker/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/test/unit/testcase.rb:8:in `<module:Unit>'
undefined method`_run_suite' for class `Test::Unit::Runner' (NameError)
/Users/Thoughtworker/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/test/unit.rb:676:in`class:Runner'
/Users/Thoughtworker/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/test/unit.rb:261:in `<module:Unit>'
/Users/Thoughtworker/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/test/unit.rb:15:in`module:Test'
/Users/Thoughtworker/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/test/unit.rb:7:in `<top (required)>'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/core_ext/disable_mini_and_test_unit_autorun.rb:25:in`require'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/core_ext/disable_mini_and_test_unit_autorun.rb:25:in `<top (required)>'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/runtime.rb:22:in`require'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/runtime.rb:22:in `initialize'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/cli/main.rb:40:in`new'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/cli/main.rb:40:in `execute!'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/cli/main.rb:20:in`execute'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/bin/cucumber:14:in `<top (required)>'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/cucumber:23:in`load'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/cucumber:23:in `<main>'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in`eval'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `<main>'
rake aborted!
Command failed with status (1): [/Users/Thoughtworker/.rvm/rubies/ruby-2.1....]
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/rake/task.rb:104:in`run'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/gems/cucumber-1.2.5/lib/cucumber/rake/task.rb:193:in `block in define_task'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in`eval'
/Users/Thoughtworker/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => test => test:features
(See full trace by running task with --trace)
